### PR TITLE
Use standard Ruby path

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -1,4 +1,4 @@
-#! /usr/local/bin/ruby -KU
+#! /usr/bin/ruby -KU
 # -*- coding: utf-8 -*-
 
 require 'unicode'


### PR DESCRIPTION
as on most systems it's in `/usr/bin`.

_ _ _ _

Or remove it completely. The permissions for the file are currently non-executable, so it's of no use.